### PR TITLE
Expose check_depends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aur-rpc"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "reqwest",
  "serde",

--- a/src/models.rs
+++ b/src/models.rs
@@ -37,6 +37,7 @@ pub struct PackageInfo {
     pub depends: Vec<String>,
     pub make_depends: Vec<String>,
     pub opt_depends: Vec<String>,
+    pub check_depends: Vec<String>
 }
 
 impl From<PackageInfoRaw> for PackageInfo {
@@ -63,6 +64,7 @@ impl From<PackageInfoRaw> for PackageInfo {
             depends: info.depends,
             opt_depends: info.opt_depends,
             make_depends: info.make_depends,
+            check_depends: info.check_depends,
         }
     }
 }
@@ -78,6 +80,8 @@ pub(crate) struct PackageInfoRaw {
     pub depends: Vec<String>,
     #[serde(default)]
     pub opt_depends: Vec<String>,
+    #[serde(default)]
+    pub check_depends: Vec<String>,
     #[serde(default)]
     pub make_depends: Vec<String>,
     pub description: Option<String>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -69,7 +69,7 @@ impl From<PackageInfoRaw> for PackageInfo {
     }
 }
 
-/// Full packge info with all fields as a workaround
+/// Full package info with all fields as a workaround
 /// as serde doesn't support aliases in flattened structs
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -116,7 +116,7 @@ pub(crate) struct AURResponse<T> {
     pub error: Option<String>,
 }
 
-/// Represents the type of aur response
+/// Represents the type of AUR response
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ResponseType {

--- a/src/rpcs/search.rs
+++ b/src/rpcs/search.rs
@@ -30,13 +30,13 @@ pub enum SearchField {
     NameDesc,
     /// Searches by package maintainer
     Maintainer,
-    /// Searches for packages that depend on the given keywods
+    /// Searches for packages that depend on the given keywords
     Depends,
     /// Searches for packages that require the given keywords to be build
     MakeDepends,
-    /// Searches for packages that optionally depend on the given keywods
+    /// Searches for packages that optionally depend on the given keywords
     OptDepends,
-    /// Searches for packages that require the given keywods to be present
+    /// Searches for packages that require the given keywords to be present
     CheckDepends,
 }
 


### PR DESCRIPTION
This PR exposes check_depends so people who use this crate can see what dependencies the check function in the pkgbuild relies on.

Closes #1 